### PR TITLE
Feature/login csrf check

### DIFF
--- a/users/static/js/login.js
+++ b/users/static/js/login.js
@@ -1,3 +1,36 @@
-window.onload = function() {
-  document.getElementById("id_email").focus();
-}
+window.onload = () => {
+  function getCookie(name) {
+    let cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+      const cookies = document.cookie.split(';');
+      for (let i = 0; i < cookies.length; i += 1) {
+        const cookie = cookies[i].trim();
+
+        // Does this cookie string begin with the name we want?
+        if (cookie.substring(0, name.length + 1) === (`${name}=`)) {
+          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+          break;
+        }
+      }
+    }
+
+    return cookieValue;
+  }
+
+  const cookie = getCookie('csrftoken');
+
+  const interval = setInterval(() => {
+    if (cookie !== getCookie('csrftoken')) {
+      clearInterval(interval);
+      window.location.reload();
+    }
+  }, 1000);
+
+
+  const loginForm = document.getElementById('login-form');
+  const loginField = document.getElementById(loginForm.dataset.usernameFieldId);
+  if (loginField) {
+    loginField.focus();
+    loginField.select();
+  }
+};

--- a/users/static/js/login.js
+++ b/users/static/js/login.js
@@ -22,6 +22,14 @@ window.onload = () => {
   const interval = setInterval(() => {
     if (cookie !== getCookie('csrftoken')) {
       clearInterval(interval);
+
+      const next = document.getElementById('id_next');
+
+      if (next) {
+        window.location.href = next.value;
+        return;
+      }
+
       window.location.reload();
     }
   }, 1000);

--- a/users/templates/registration/login.pug
+++ b/users/templates/registration/login.pug
@@ -6,7 +6,7 @@ block javascripts
   script(src="{% static 'js/login.js' %}")
 
 block content
-  form.form-signin.form-horizontal.mt-4(action='', method='post')
+  form#login-form.form-signin.form-horizontal.mt-4(action='', method='post', data-username-field-id="id_{{form.email_field.name}}")
     {% csrf_token %}
 
     .form-signin-inner

--- a/users/templates/registration/login.pug
+++ b/users/templates/registration/login.pug
@@ -16,6 +16,7 @@ block content
 
       for field in form.hidden_fields
         | {{field}}
+      input#id_next(type='hidden', name='next', value='{{ next }}')
 
       for field in form.visible_fields
 


### PR DESCRIPTION
Add cookie watcher on login to avoid CSRF token errors

When a users opens 2 tabs with the login, one login will fail, so we
reload the page