### PR TITLE
fix: allow shortcut link host

### DIFF
--- a/project/local_settings.py.default
+++ b/project/local_settings.py.default
@@ -29,6 +29,7 @@ EMAIL_EMAIL_USE_TLS = True
 
 LOCALLY_ALLOWED_HOSTS = [
     'localhost',
+    '127.0.0.1',
 ]
 
 ADMINS = ()


### PR DESCRIPTION
El link que muestra `runserver` por defecto está roto (DisallowedHost)

![image](https://user-images.githubusercontent.com/5559379/71695738-c8c3bb80-2d91-11ea-92a7-555650a1fb54.png)
