### PR TITLE
chore: add .tags file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ webpack-stats.json
 
 .vscode/
 *.dump
+.tags


### PR DESCRIPTION
El archivo .tags se crea automáticamente al editar archivos con vim en el directorio del proyecto