### PR TITLE
chore: update pipenv step on circle ci to allow cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,11 @@ jobs:
 
       - run:
           name: install python packages
-          command: |
-            pipenv --python 3.8
-            pipenv install --deploy
+          command: pipenv sync
+
+      - run:
+          name: check if Pipfile.lock is outdated
+          command: pipenv update --outdated
 
       - save_cache:
           key: cache-{{ checksum "Pipfile.lock" }}


### PR DESCRIPTION
The build 84 from https://app.circleci.com/pipelines/github/magnet-cl/django-project-template?branch=chore%2Fpipenv-on-circle-ci has a package changed only on Pipfile to test if Pipfile.lock is outdated.

With the rest of the builds the cache can be reviewed.