### PR TITLE
change: call save method on BaseModel.update with a parameter to avoid it

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ and `to_dict`.
 #### update
 
   This is a shortcut method, it basically sets all keyword arguments as
-  attributes on the calling object, then it stores ontly those values into 
+  attributes on the calling object, then it stores only those values into 
   the database. 
 
   To store values into the database, this method uses the `save` method with

--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ Every model has to inherit from the class BaseModel. This allows that every
 model has the fields `created_at` and `updated_at` and methods like `to_json`
 and `to_dict`.
 
+#### update
+
+  This is a shortcut method, it basically sets all keyword arguments as
+  attributes on the calling object, then it stores ontly those values into 
+  the database. 
+
+  To store values into the database, this method uses the `save` method with
+  the `update_fields` parameter, but if you want to skip the save method, you
+  can pass the parameter `skip_save=True` when calling update (useful when 
+  you want to avoid calling save signals).
+
 ### OrderableModel
 
 This model inherits from BaseModel. It adds the `display_order` field to allow

--- a/base/models.py
+++ b/base/models.py
@@ -74,12 +74,14 @@ class BaseModel(AuditMixin, models.Model):
     # public methods
     def update(self, skip_save=False, **kwargs):
         """
-        Set the attributes passed on kwargs on the object and store them
-        in the database
-        highly recommended when you need to save just one field
+        This is a shortcut method, it basically sets all keyword arguments as
+        attributes on the calling object, then it stores ontly those values
+        into the database.
 
-        if skip_save=True is passed, then the save method will be skipped
-        (this can be useful when you want to avoid signals sent on save)
+        To store values into the database, this method uses the `save` method
+        with the `update_fields` parameter, but if you want to skip the save
+        method, you can pass the parameter `skip_save=True` when calling update
+        (useful when you want to avoid calling save signals).
         """
         kwargs['updated_at'] = timezone.now()
 
@@ -90,7 +92,6 @@ class BaseModel(AuditMixin, models.Model):
             self.__class__.objects.filter(pk=self.pk).update(**kwargs)
         else:
             self.save(update_fields=kwargs.keys())
-
 
     def to_dict(instance, fields=None, exclude=None, include_m2m=True):
         """

--- a/base/models.py
+++ b/base/models.py
@@ -72,17 +72,25 @@ class BaseModel(AuditMixin, models.Model):
         abstract = True
 
     # public methods
-    def update(self, **kwargs):
-        """ proxy method for the QuerySet: update method
+    def update(self, skip_save=False, **kwargs):
+        """
+        Set the attributes passed on kwargs on the object and store them
+        in the database
         highly recommended when you need to save just one field
 
+        if skip_save=True is passed, then the save method will be skipped
+        (this can be useful when you want to avoid signals sent on save)
         """
         kwargs['updated_at'] = timezone.now()
 
         for kw in kwargs:
             self.__setattr__(kw, kwargs[kw])
 
-        self.__class__.objects.filter(pk=self.pk).update(**kwargs)
+        if skip_save:
+            self.__class__.objects.filter(pk=self.pk).update(**kwargs)
+        else:
+            self.save(update_fields=kwargs.keys())
+
 
     def to_dict(instance, fields=None, exclude=None, include_m2m=True):
         """

--- a/base/models.py
+++ b/base/models.py
@@ -75,7 +75,7 @@ class BaseModel(AuditMixin, models.Model):
     def update(self, skip_save=False, **kwargs):
         """
         This is a shortcut method, it basically sets all keyword arguments as
-        attributes on the calling object, then it stores ontly those values
+        attributes on the calling object, then it stores only those values
         into the database.
 
         To store values into the database, this method uses the `save` method


### PR DESCRIPTION
Django has a way to only save a couple of attibutes of the model (the update_fields paramter on save method).

This PR updates the BaseModel.update method to use save(update_fields=...) while allowing the use of the previous way to avoid calling the save method. This method is now useful to set and store an attribute in a single line.