### PR TITLE
add: ClearSessionsCronJob to clear expired sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,21 @@ want to ignore a field, you can add it to LOG_IGNORE_FIELDS in settings.
 
 The project doesn't log any action made through automatic tasks.
 
+## Crons
+
+The project has a dependency installed called
+[django-cron](https://github.com/tivix/django-cron) that allows to program
+classes that can later be called using the system cron (this means that when
+app is deployed, a cron must call django-cron so your classes can be
+executed). Every cron job class that you create for your project should
+inherit from BaseCronJob in base/cron.py, and should be registered under 
+"CRON_CLASSES" in project/settings.py.
+
+There is a class already registered: base.cron.ClearSessionsCronJob. This is a
+job that clears expired sessions from the database, everyday at 3:00 am. See the documentation [here](
+https://docs.djangoproject.com/en/3.1/topics/http/sessions/#clearing-the-session-store)).
+
+
 ## Deployment
 
 Deployment is automated with Ansible, which is installed by quickstart. Add your servers to `ansible/inventory.yaml` and deploy with:

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ inherit from BaseCronJob in base/cron.py, and should be registered under
 
 There is a class already registered: base.cron.ClearSessionsCronJob. This is a
 job that clears expired sessions from the database, everyday at 3:00 am. See the documentation [here](
-https://docs.djangoproject.com/en/3.1/topics/http/sessions/#clearing-the-session-store)).
+https://docs.djangoproject.com/en/2.2/topics/http/sessions/#clearing-the-session-store)).
 
 
 ## Deployment

--- a/base/cron.py
+++ b/base/cron.py
@@ -1,6 +1,10 @@
+# django
+from django.contrib.sessions.management.commands import clearsessions
+
 # django cron
 from django_cron import CronJobBase
 from django_cron import CronJobManager
+from django_cron import Schedule
 
 
 class BaseCronJob(CronJobBase):
@@ -11,3 +15,15 @@ class BaseCronJob(CronJobBase):
         with CronJobManager(cls, silent) as manager:
             lock = manager.lock_class(cls, manager.silent)
             lock.release()
+
+
+class ClearSessionsCronJoab(CronJobBase):
+    RUN_AT_TIMES = ('03:00',)
+
+    schedule = Schedule(
+        run_at_times=RUN_AT_TIMES,
+    )
+    code = 'base.ClearSessionsCronJoab'
+
+    def do(self):
+        clearsessions.Command().handle()

--- a/base/cron.py
+++ b/base/cron.py
@@ -17,13 +17,13 @@ class BaseCronJob(CronJobBase):
             lock.release()
 
 
-class ClearSessionsCronJoab(CronJobBase):
+class ClearSessionsCronJob(CronJobBase):
     RUN_AT_TIMES = ('03:00',)
 
     schedule = Schedule(
         run_at_times=RUN_AT_TIMES,
     )
-    code = 'base.ClearSessionsCronJoab'
+    code = 'base.ClearSessionsCronJob'
 
     def do(self):
         clearsessions.Command().handle()

--- a/project/settings.py
+++ b/project/settings.py
@@ -396,5 +396,5 @@ LOG_IGNORE_FIELDS = [
 
 # django-cron
 CRON_CLASSES = [
-    'base.cron.ClearSessionsCronJoab',
+    'base.cron.ClearSessionsCronJob',
 ]

--- a/project/settings.py
+++ b/project/settings.py
@@ -393,3 +393,8 @@ LOG_IGNORE_FIELDS = [
     'id',
     'date_joined',
 ]
+
+# django-cron
+CRON_CLASSES = [
+    'base.cron.ClearSessionsCronJoab',
+]


### PR DESCRIPTION
Django does not provide automatic purging of expired sessions. Therefore, it’s our job to purge expired sessions on a regular basis. Django provides a clean-up management command for this purpose: clearsessions. A cron job will call it every day at 3:00 am

https://docs.djangoproject.com/en/3.1/topics/http/sessions/#clearing-the-session-store