### PR TITLE
added slug case in urls test

### DIFF
--- a/base/tests.py
+++ b/base/tests.py
@@ -138,17 +138,17 @@ class UrlsTest(BaseTestCase):
 
         '/users/{user_id}/comments/'
         """
-        param_converters_names = url_pattern.pattern.converters.items()
+        param_converter_name = url_pattern.pattern.converters.items()
 
         params = {}
-        if not param_converters_names:
+        if not param_converter_name:
             return
 
         callback = url_pattern.callback
 
         obj = None
 
-        for param_name, converter in param_converters_names:
+        for param_name, converter in param_converter_name:
             if param_name == 'pk' and hasattr(callback, 'view_class'):
                 model_name = underscore(
                     url_pattern.callback.view_class.model.__name__

--- a/base/tests.py
+++ b/base/tests.py
@@ -155,7 +155,7 @@ class UrlsTest(BaseTestCase):
                 )
                 params['pk'] = self.default_params['{}_id'.format(model_name)]
                 obj = self.default_objects[model_name]
-            elif isinstance(converter, SlugConverter) and hasattr(callback, 'view_class'):
+            elif isinstance(converter, SlugConverter) and hasattr(callback, 'view_class'): # noqa
                 model_name = underscore(
                     url_pattern.callback.view_class.model.__name__
                 )

--- a/base/utils.py
+++ b/base/utils.py
@@ -14,6 +14,7 @@ import pytz
 # django
 from django.apps import apps
 from django.utils import timezone
+from django.db import models
 
 
 def today():
@@ -140,3 +141,11 @@ def date_to_datetime(date):
         )
 
     return r_datetime
+
+
+def get_slug_fields(model):
+    slug_fields = []
+    for field in model._meta.fields:
+        if isinstance(field, models.SlugField):
+            slug_fields.append(field)
+    return slug_fields


### PR DESCRIPTION
Base Urls Test doesn't take into consideration when using slugs instead of object ids as url params.

This PR adds support for testing urls with slugs.