### PR TITLE
feat: mockup: add set_required_time

### DIFF
--- a/base/mockups.py
+++ b/base/mockups.py
@@ -98,6 +98,10 @@ class Mockup(object):
         if field not in data:
             data[field] = timezone.now().date()
 
+    def set_required_time(self, data, field, **kwargs):
+        if field not in data:
+            data[field] = timezone.now().time()
+
     def set_required_datetime(self, data, field, **kwargs):
         if field not in data:
             data[field] = timezone.now()


### PR DESCRIPTION
Current Mockup implementation lacks a method to generate a `time` object. This may be helpful for testing models with TimeFields.