### PR TITLE
security: don't expose superuser password

### DIFF
--- a/users/migrations/0002_initial_admin_user.py
+++ b/users/migrations/0002_initial_admin_user.py
@@ -18,7 +18,8 @@ def create_users(apps, schema_editor):
         is_staff=True,
         is_superuser=True,
         last_name='Smith',
-        password=make_password('codigofuente'),
+        password='bcrypt_sha256$$2b$12$'
+                 'TM9AaqBES87B9Dp6z0LJoude3Y4nMxJSVUw/kDe7VCGq.dcUI2cUW',
     )
 
 


### PR DESCRIPTION
Cambia la contraseña por defecto (`codigofuente`) por un hash precalculado.
La contraseña real será divulgada por canales más internos.