### PR TITLE
chore: organize related email settings in dict and allow logging overrides

### DIFF
--- a/project/local_settings.py.default
+++ b/project/local_settings.py.default
@@ -46,3 +46,18 @@ SECRET_KEY = 'CHANGE ME'
 
 RECAPTCHA_PUBLIC_KEY = ''
 RECAPTCHA_PRIVATE_KEY = ''
+
+# If you have special logging needs, such as overriding the handlers, use
+# LOCAL_LOGGING_HANDLERS, LOGAL_LOGGING_LOGGERS or LOCAL_LOGGING.
+# The following is an example of overriding the 'mail_admins' handler so
+# it can use the SMTP backend regardless of the global email backend.
+# LOCAL_LOGGING_HANDLERS = {
+#     'mail_admins': {
+#         'class': 'django.utils.log.AdminEmailHandler',
+#         'filters': ['require_debug_false'],
+#         'formatter': 'standard',
+#         'level': 'ERROR',
+#         'email_backend': 'django.core.mail.backends.smtp.EmailBackend',
+#     }
+# }
+

--- a/project/local_settings.py.default
+++ b/project/local_settings.py.default
@@ -20,12 +20,18 @@ LOCALLY_INSTALLED_APPS = [
 ]
 
 ENABLE_EMAILS = True
-
-EMAIL_HOST = ''
-EMAIL_HOST_USER = ''
-EMAIL_HOST_PASSWORD = ''
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
+EMAIL_SETTINGS = {
+    'EMAIL_HOST': '',
+    'EMAIL_HOST_USER': '',
+    'EMAIL_HOST_PASSWORD': '',
+    'EMAIL_PORT': 587,
+    'EMAIL_USE_TLS': True,
+    # Default email address to use for various automated correspondence from
+    # the site managers
+    'DEFAULT_FROM_EMAIL': '',
+    'SERVER_EMAIL': '',
+    'EMAIL_SENDER_NAME': '',
+}
 
 LOCALLY_ALLOWED_HOSTS = [
     'localhost',

--- a/project/settings.py
+++ b/project/settings.py
@@ -335,6 +335,15 @@ LOGGING = {
 }
 
 
+# Override logging conf
+LOCAL_LOGGING = get_local_value('LOCAL_LOGGING', dict())
+LOCAL_LOGGING_HANDLERS = get_local_value('LOCAL_LOGGING_HANDLERS', dict())
+LOCAL_LOGGING_LOGGERS = get_local_value('LOCAL_LOGGING_LOGGERS', dict())
+LOGGING['loggers'].update(LOCAL_LOGGING_LOGGERS)
+LOGGING['handlers'].update(LOCAL_LOGGING_HANDLERS)
+LOGGING.update(LOCAL_LOGGING)
+
+
 # ### Login as settings ###
 CAN_LOGIN_AS = "base.utils.can_loginas"
 LOGOUT_URL = reverse_lazy('loginas-logout')

--- a/project/settings.py
+++ b/project/settings.py
@@ -114,18 +114,22 @@ INSTALLED_APPS = [
     'parameters',
 ]
 
+EMAIL_SETTINGS = get_local_value('EMAIL_SETTINGS', dict())
+
 # Email settings, uncomment if your project sends emails
 # You must set this values in local_settings
-EMAIL_HOST = get_local_value('EMAIL_HOST', '')
-EMAIL_HOST_USER = get_local_value('EMAIL_HOST_USER', '')
-EMAIL_HOST_PASSWORD = get_local_value('EMAIL_HOST_PASSWORD', '')
-EMAIL_PORT = get_local_value('EMAIL_PORT', 587)
-EMAIL_USE_TLS = get_local_value('EMAIL_USE_TLS', True)
+DEFAULT_FROM_EMAIL = EMAIL_SETTINGS.get(
+    'DEFAULT_FROM_EMAIL',
+    'webmaster@localhost'
+)
+SERVER_EMAIL = EMAIL_SETTINGS.get('SERVER_EMAIL', 'root@localhost')
+EMAIL_SENDER_NAME = EMAIL_SETTINGS.get('EMAIL_SENDER_NAME', 'DPT project')
 
-# Default email address to use for various automated correspondence from
-# the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
-EMAIL_SENDER_NAME = 'My project'
+EMAIL_HOST = EMAIL_SETTINGS.get('EMAIL_HOST', '')
+EMAIL_HOST_USER = EMAIL_SETTINGS.get('EMAIL_HOST_USER', '')
+EMAIL_HOST_PASSWORD = EMAIL_SETTINGS.get('EMAIL_HOST_PASSWORD', '')
+EMAIL_PORT = EMAIL_SETTINGS.get('EMAIL_PORT', 587)
+EMAIL_USE_TLS = EMAIL_SETTINGS.get('EMAIL_USE_TLS', True)
 
 if DEBUG:
     INSTALLED_APPS += [


### PR DESCRIPTION
- Organize email settings in a single dict: `EMAIL_SETTINGS`.
- Allow to override the logging settings at handler/logger level or a complete level.