### PR TITLE
fix base model to dict method

### DIFF
--- a/base/models.py
+++ b/base/models.py
@@ -113,7 +113,7 @@ class BaseModel(AuditMixin, models.Model):
             if exclude and f.name in exclude:
                 continue
             if isinstance(f, models.fields.related.ForeignKey):
-                data[f.name + '_id'] = f.value_from_object(instance)
+                data[f.attname] = instance.__dict__.get(f.attname)
             elif isinstance(f, models.fields.related.ManyToManyField):
                 if include_m2m:
                     # If the object doesn't have a primary key yet, just use an
@@ -130,7 +130,7 @@ class BaseModel(AuditMixin, models.Model):
                             )
                         )
             else:
-                data[f.name] = f.value_from_object(instance)
+                data[f.name] = instance.__dict__.get(f.name)
         return data
 
     def to_json(self, fields=None, exclude=None, **kargs):


### PR DESCRIPTION
Fixed a bug where some QuerySet methods that partially loaded the fields of an instance of BaseModel would cause a recursion error (and recursive queries to the db).

Queryset methods that would cause this situation would be only, defer and some raw queries.